### PR TITLE
Improved image read

### DIFF
--- a/OpenCV_max.py
+++ b/OpenCV_max.py
@@ -15,7 +15,6 @@ import pandas as pd
 import os
 import pickle
 
-from keras.preprocessing import image
 from sklearn.metrics import accuracy_score
 
 
@@ -62,10 +61,9 @@ folderpath = 'CERTH_ImageBlurDataset/EvaluationSet/DigitalBlurSet/'
 for filename in os.listdir(folderpath):
     if filename != '.DS_Store':
         imagepath = folderpath + filename
-        img = image.load_img(imagepath, target_size=input_size)
-        X_test.append(np.asarray(img))
         blur = dgbset[dgbset['MyDigital Blur'] == filename].iloc[0]['Blur Label']
-        gray = cv2.cvtColor(np.asarray(img), cv2.COLOR_BGR2GRAY)
+        gray = cv2.resize(cv2.imread(imagepath, cv2.IMREAD_GRAYSCALE), input_size)
+        X_test.append(gray)
         maxval = np.max(cv2.convertScaleAbs(cv2.Laplacian(gray,3)))
         if maxval < threshold:
             y_pred.append(1)
@@ -92,10 +90,9 @@ folderpath = 'CERTH_ImageBlurDataset/EvaluationSet/NaturalBlurSet/'
 for filename in os.listdir(folderpath):
     if filename != '.DS_Store':
         imagepath = folderpath + filename
-        img = image.load_img(imagepath, target_size=input_size)
-        X_test.append(np.asarray(img))
         blur = nbset[nbset['Image Name'] == filename.split('.')[0]].iloc[0]['Blur Label']
-        gray = cv2.cvtColor(np.asarray(img), cv2.COLOR_BGR2GRAY)
+        gray = cv2.resize(cv2.imread(imagepath, cv2.IMREAD_GRAYSCALE), input_size)
+        X_test.append(gray)
         maxval = np.max(cv2.convertScaleAbs(cv2.Laplacian(gray,3)))
         if maxval < threshold:
             y_pred.append(1)

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ To train the CNN:
 ## Maximum of Laplacian
 **Using OpenCV2**
 
-An accuracy of **63.58%** is achieved using this method.
+An accuracy of **63.72%** is achieved using this method.
 
 `gray = cv2.cvtColor(img, cv2.COLOR_BGR2GRAY) `
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ To train the CNN:
 
 An accuracy of **63.72%** is achieved using this method.
 
-`gray = cv2.cvtColor(img, cv2.COLOR_BGR2GRAY) `
+`gray = cv2.resize(cv2.imread(imagepath, cv2.IMREAD_GRAYSCALE), input_size)`
 
 `numpy.max(cv2.convertScaleAbs(cv2.Laplacian(gray,3)))`
 


### PR DESCRIPTION
### This PR Changes:

Method of reading images.

### Results:

Before: `python3 OpenCV_max.py  189.98s user 10.78s system 99% cpu 3:21.02 total`
After: `python3 OpenCV_max.py  59.93s user 2.93s system 100% cpu 1:02.29 total`

Around 70% improvement in time and 0.2% in accuracy.

resolves #3 